### PR TITLE
Default IPv4 Address prefix /12 → /32 (rely on AllowedIPs for routing)

### DIFF
--- a/wgcf-connector.sh
+++ b/wgcf-connector.sh
@@ -10,7 +10,7 @@ cat > /app/output/wgcf-connector-$(jq -r .registration_id[0] < /var/lib/cloudfla
 # Organization: $(jq -r .account.organization < /var/lib/cloudflare-warp/conf.json)
 [Interface]
 PrivateKey = $(jq -r .secret_key < /var/lib/cloudflare-warp/reg.json)
-Address = $(jq -r .interface.v6 < /var/lib/cloudflare-warp/conf.json)/64, $(jq -r .interface.v4 < /var/lib/cloudflare-warp/conf.json)/12
+Address = $(jq -r .interface.v6 < /var/lib/cloudflare-warp/conf.json)/64, $(jq -r .interface.v4 < /var/lib/cloudflare-warp/conf.json)/32
 DNS = 2606:4700:4700::1111, 2606:4700:4700::1001, 1.1.1.1, 1.0.0.1
 MTU = 1420
 

--- a/wgcf-connector.sh
+++ b/wgcf-connector.sh
@@ -10,7 +10,7 @@ cat > /app/output/wgcf-connector-$(jq -r .registration_id[0] < /var/lib/cloudfla
 # Organization: $(jq -r .account.organization < /var/lib/cloudflare-warp/conf.json)
 [Interface]
 PrivateKey = $(jq -r .secret_key < /var/lib/cloudflare-warp/reg.json)
-Address = $(jq -r .interface.v6 < /var/lib/cloudflare-warp/conf.json)/64, $(jq -r .interface.v4 < /var/lib/cloudflare-warp/conf.json)/32
+Address = $(jq -r .interface.v6 < /var/lib/cloudflare-warp/conf.json)/128, $(jq -r .interface.v4 < /var/lib/cloudflare-warp/conf.json)/32
 DNS = 2606:4700:4700::1111, 2606:4700:4700::1001, 1.1.1.1, 1.0.0.1
 MTU = 1420
 


### PR DESCRIPTION
## Background

The Cloudflare WARP API responds to a connector registration with only the IP
itself, **not the prefix length** of the IP profile the device was assigned
from. I verified this by registering a connector inside the container and
dumping `/var/lib/cloudflare-warp/conf.json`:

```json
"interface": {
  "v4": "10.255.0.5",
  "v6": "2606:4700:cf1:1000::18"
}
```

So the current `wgcf-connector.sh` hardcodes `/12`, which matches the legacy
CGNAT pool `100.64.0.0/10` but no longer matches user-defined device IPv4
subnets. With [custom device IPv4 ranges](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/device-ips/)
you can put WARP Connectors on, say, `10.255.0.0/16`, in which case `/12`
becomes a supernet that overlaps private VPC allocations like
`10.16.0.0/12` you might have on the routing side.

## Change

`/12` → `/32` on the IPv4 portion of `Address =`.

```diff
- Address = .../64, .../12
+ Address = .../64, .../32
```

## Why /32 is safe (and arguably better)

In WireGuard, the `Address` prefix has two effects:

1. Assigns the IP to the wg interface.
2. Causes `wg-quick` to install a *connected route* of that prefix on the
   interface, in addition to the routes derived from `AllowedIPs`.

The actual reachability gate is `AllowedIPs`. Packets whose source is not
inside the peer's `AllowedIPs` are dropped by the kernel module regardless
of what's in the routing table. Conversely, packets to destinations covered
by `AllowedIPs` are sent over the tunnel.

So with `/32`:

- wg interface still has its IP, just as a host route.
- The supernet connected route is gone — routing is entirely
  `AllowedIPs`-driven, which is the source of truth WireGuard already
  expects. No surprises, no implicit routes covering ranges the user did
  not opt into.
- Communication is unchanged: as long as `AllowedIPs` includes the relevant
  peer ranges, traffic flows the same.

For the original CGNAT case (`100.96.0.x` device IPs), the implicit
`100.64.0.0/12` connected route from `/12` was harmless because that range
is reserved for CF and unlikely to clash with anything else. Once the user
moves devices to RFC1918 (`10.x`, `172.16.x`, `192.168.x`), the implicit
supernet route can collide with their own private networks. `/32` removes
that footgun while keeping the default behavior functionally equivalent for
the original CGNAT flow.

## Compatibility

- Existing users on the default `100.64.0.0/10` device IP range: no
  effective change. `AllowedIPs` already covers the relevant ranges; the
  removed implicit `/12` connected route is replaced by the explicit
  `AllowedIPs`-derived routes that `wg-quick` already installs.
- Users with custom device IPv4 ranges (RFC1918): correctness improvement —
  no more spurious `/12` route potentially colliding with their VPC CIDRs.

## Verified on

Rocky Linux 10 gateway VM with a custom device IPv4 range of `10.255.0.0/16`.
Connector wg0 address is `10.255.0.x` with `AllowedIPs = 10.255.0.0/16,
10.254.0.0/16`. Routes after `wg-quick up`:

```
# /12 (before)
10.240.0.0/12 dev wg0 proto kernel scope link src 10.255.0.3

# /32 (after)
10.254.0.0/16 dev wg0 scope link
10.255.0.0/16 dev wg0 scope link
```

The `/32` version is more honest about what the tunnel actually carries.